### PR TITLE
[#32-ux-search] 검색 정렬, 필터링 기능 추가 및 UX 개선

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -62,14 +62,15 @@ chrome.webNavigation.onCompleted.addListener((details) => {
  * @param {*} url
  */
 function checkAndEmphasisButton(tabId, url) {
-    const targetUrls = ["chatgpt.com", "claude.ai", "gemini.google.com"];
+    // const targetUrls = ["chatgpt.com", "claude.ai", "gemini.google.com"];
     if (!url) return;
 
-    if (targetUrls.some((targetUrl) => url.includes(targetUrl)) && !panelOpen) {
-        chrome.tabs.sendMessage(tabId, { action: "emphasizeButton" });
-    } else {
-        chrome.tabs.sendMessage(tabId, { action: "deemphasizeButton" });
-    }
+    // 240815 미사용
+    // if (targetUrls.some((targetUrl) => url.includes(targetUrl)) && !panelOpen) {
+    //     chrome.tabs.sendMessage(tabId, { action: "emphasizeButton" });
+    // } else {
+    //     chrome.tabs.sendMessage(tabId, { action: "deemphasizeButton" });
+    // }
 }
 
 /**
@@ -87,7 +88,7 @@ function openSidePanel(tabId, windowId) {
     panelOpen = true;
 
     // 패널 open 시, 강조 off
-    chrome.tabs.sendMessage(tabId, { action: "deemphasizeButton" });
+    // chrome.tabs.sendMessage(tabId, { action: "deemphasizeButton" });
 }
 
 /**

--- a/public/content.js
+++ b/public/content.js
@@ -24,42 +24,36 @@ buttonContainer.addEventListener("click", () => {
 
 document.body.appendChild(buttonContainer);
 
-// 버튼 강조, 해제 함수
-function emphasizeButton() {
-    console.log("emphasize!");
-    const button = document.getElementById("float-btn");
-    if (button) {
-        button.classList.add("emphasized");
+// // 버튼 강조, 해제 함수
+// function emphasizeButton() {
+//     console.log("emphasize!");
+//     const button = document.getElementById("float-btn");
+//     if (button) {
+//         button.classList.add("emphasized");
 
-        // 툴팁 추가 (이미 있으면 추가하지 않음)
-        if (!button.querySelector(".tooltip")) {
-            const tooltip = document.createElement("div");
-            tooltip.className = "tooltip";
-            tooltip.textContent = "사이드 패널 열기";
-            button.insertBefore(tooltip, button.firstChild);
-        }
-    }
-}
+//         // 툴팁 추가 (이미 있으면 추가하지 않음)
+//         if (!button.querySelector(".tooltip")) {
+//             const tooltip = document.createElement("div");
+//             tooltip.className = "tooltip";
+//             tooltip.textContent = "사이드 패널 열기";
+//             button.insertBefore(tooltip, button.firstChild);
+//         }
+//     }
+// }
 
-function deemphasizeButton() {
-    console.log("deemphasize!");
-    const button = document.getElementById("float-btn");
-    if (button) {
-        button.classList.remove("emphasized");
-        const tooltip = button.querySelector(".tooltip");
-        if (tooltip) {
-            tooltip.remove();
-        }
-    }
-}
+// function deemphasizeButton() {
+//     console.log("deemphasize!");
+//     const button = document.getElementById("float-btn");
+//     if (button) {
+//         button.classList.remove("emphasized");
+//         const tooltip = button.querySelector(".tooltip");
+//         if (tooltip) {
+//             tooltip.remove();
+//         }
+//     }
+// }
 
 // [메시지 수신 Listener]
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     console.log("***Message received", request, sender);
-
-    if (request.action === "emphasizeButton") {
-        emphasizeButton();
-    } else if (request.action === "deemphasizeButton") {
-        deemphasizeButton();
-    }
 });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,61 +1,72 @@
 {
-    "manifest_version": 3,
-    "version": "1.0.4",
-    "short_name": "Pocket Prompt",
-    "name": "Pocket Prompt",
-    "icons": {
-        "16": "images/logo.png",
-        "32": "images/logo.png",
-        "48": "images/logo.png",
-        "128": "images/logo.png"
-    },
-    "action": {
-        "default_title": "Click to open panel"
-    },
-    "side_panel": {
-        "default_path": "index.html"
-    },
-    "permissions": [
-        "identity",
-        "storage",
-        "sidePanel",
-        "commands",
-        "scripting",
-        "webNavigation"
-    ],
-    "host_permissions": [
-        "https://chatgpt.com/*",
-        "https://claude.ai/*",
-        "https://gemini.google.com/*"
-    ],
-    "background": {
-        "service_worker": "background.js"
-    },
-    "content_scripts": [
-        {
-            "matches": ["<all_urls>"],
-            "css": ["style.css"],
-            "js": ["content.js"]
-        }
-    ],
-    "web_accessible_resources": [
-        {
-            "resources": ["images/*"],
-            "matches": ["<all_urls>"]
-        }
-    ],
-    "commands": {
-        "_execute_action": {
-            "suggested_key": {
-                "default": "Ctrl+P",
-                "mac": "Command+P"
-            }
-        }
-    },
-    "oauth2": {
-        "scopes": [
-            "https://www.googleapis.com/auth/userinfo.profile",
-            "https://www.googleapis.com/auth/userinfo.email"
-        ]
+  "manifest_version": 3,
+  "version": "1.0.4",
+  "short_name": "Pocket Prompt",
+  "name": "Pocket Prompt",
+  "icons": {
+    "16": "images/logo.png",
+    "32": "images/logo.png",
+    "48": "images/logo.png",
+    "128": "images/logo.png"
+  },
+  "action": {
+    "default_title": "Click to open panel"
+  },
+  "side_panel": {
+    "default_path": "index.html"
+  },
+  "permissions": [
+    "identity",
+    "storage",
+    "sidePanel",
+    "commands",
+    "scripting",
+    "webNavigation"
+  ],
+  "host_permissions": [
+    "https://chatgpt.com/*",
+    "https://claude.ai/*",
+    "https://gemini.google.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "css": [
+        "style.css"
+      ],
+      "js": [
+        "content.js"
+      ]
     }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "images/*"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
+  ],
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Ctrl+P",
+        "mac": "Command+P"
+      }
+    }
+  },
+  "oauth2": {
+    "scopes": [
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "https://www.googleapis.com/auth/userinfo.email"
+    ],
+    "client_id": "1005663016022-hbhd20hf2f8pqdc15umlg4cvqvjt288e.apps.googleusercontent.com"
+  }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1,7 +1,7 @@
 #float-btn {
     position: fixed;
     right: 0;
-    top: 30%;
+    bottom: 30%;
     cursor: pointer;
     z-index: 1000;
     padding: 10px 10px 10px 14px;

--- a/src/components/main/List.tsx
+++ b/src/components/main/List.tsx
@@ -9,6 +9,8 @@ import Search from "./Search";
 // import { GetPromptResponse } from "../../hooks/queries/prompt/useGetPrompt";
 // import { useUser } from "../../hooks/useUser";
 import SortSelectBox from "../prompt/SortSelectBox";
+import FilterSelectBox from "../prompt/FilterSelectBox";
+import { SortBy } from "../../core/Prompt";
 
 // const tutorial = dummies.data as GetPromptResponse;
 
@@ -23,12 +25,14 @@ export default function List({ type, onChangeTab }: ListProps) {
 
     const [page, setPage] = useState(1);
     const [query, setQuery] = useState<string | undefined>();
-    const [sortBy, setSortBy] = useState<string>();
+    const [sortBy, setSortBy] = useState<string>(Object.keys(SortBy)[0]);
+    const [categories, setCategories] = useState<string[]>();
     const { data: promptListData } = useGetPromptList({
         view_type: type,
         page: page,
         query: query,
         sort_by: sortBy,
+        categories: categories,
     });
 
     // 페이지 변경 시,
@@ -130,6 +134,7 @@ export default function List({ type, onChangeTab }: ListProps) {
         <ListContainer>
             <Search onEnter={handleOnEnter} onClear={handleOnClear} />
             <FilterContainer>
+                <FilterSelectBox onChange={(values) => setCategories(values)} />
                 <SortSelectBox
                     onSelect={(value) => {
                         setSortBy(value);
@@ -160,6 +165,7 @@ export default function List({ type, onChangeTab }: ListProps) {
 }
 
 const ListContainer = styled.div`
+    flex: 1;
     ${({ theme }) => theme.mixins.flexBox("column", "flex-end", "center")};
     gap: 10px;
 
@@ -168,6 +174,6 @@ const ListContainer = styled.div`
 
 const FilterContainer = styled.div`
     width: 100%;
-    ${({ theme }) => theme.mixins.flexBox("column", "flex-end", "flex-end")};
+    ${({ theme }) => theme.mixins.flexBox("row", "flex-end", "flex-end")};
     gap: 10px;
 `;

--- a/src/components/main/List.tsx
+++ b/src/components/main/List.tsx
@@ -1,10 +1,15 @@
-import { Empty, Pagination } from "antd";
+import { Empty, Pagination, Tour, TourProps } from "antd";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { useGetPromptList } from "../../hooks/queries/prompt/useGetPromptList";
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ListItem from "./ListItem";
 import Search from "./Search";
+import dummies from "../../pages/tutorial/dummies.json";
+import { GetPromptResponse } from "../../hooks/queries/prompt/useGetPrompt";
+import { useUser } from "../../hooks/useUser";
+
+const tutorial = dummies.data as GetPromptResponse;
 
 interface ListProps {
     type: string;
@@ -12,9 +17,11 @@ interface ListProps {
 export default function List({ type }: ListProps) {
     const navigate = useNavigate();
 
+    const { userData } = useUser();
+
     const [page, setPage] = useState(1);
     const [query, setQuery] = useState<string | undefined>();
-    const { data } = useGetPromptList({
+    const { data: promptListData } = useGetPromptList({
         view_type: type,
         page: page,
         query: query,
@@ -36,15 +43,53 @@ export default function List({ type }: ListProps) {
         setQuery(undefined);
     }
 
+    // TODO
+    const showTutorial = useMemo(
+        () => userData?.user?.total_prompt_executions === 0,
+        [userData]
+    );
+
+    const [isTour, setIsTour] = useState(false);
+    const tutorialRef = useRef(null);
+    const steps: TourProps["steps"] = [
+        {
+            title: "프롬프트 사용 튜토리얼",
+            description: "해당 프롬프트를 클릭해 보세요",
+            target: () => tutorialRef.current!!,
+            nextButtonProps: {
+                onClick: function navigateToTutorialPrompt() {
+                    navigate("/prompt/tutorial");
+                },
+            },
+        },
+    ];
+
+    useEffect(() => {
+        if (promptListData && showTutorial) {
+            setIsTour(true);
+        }
+    }, [promptListData, showTutorial]);
+
     return (
         <ListContainer>
             <Search onEnter={handleOnEnter} onClear={handleOnClear} />
 
-            {!data?.data.page_meta_data.total_count && (
+            {!promptListData?.data.page_meta_data.total_count && (
                 <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
             )}
 
-            {data?.data.prompt_info_list.map((pt) => (
+            {/* Tutorial */}
+            {showTutorial && (
+                <div ref={tutorialRef}>
+                    <ListItem
+                        key={"tutorial"}
+                        prompt={tutorial}
+                        onClick={() => navigate(`/prompt/tutorial`)}
+                    />
+                </div>
+            )}
+
+            {promptListData?.data.prompt_info_list.map((pt) => (
                 <ListItem
                     key={pt.id}
                     prompt={pt}
@@ -53,10 +98,18 @@ export default function List({ type }: ListProps) {
             ))}
 
             <Pagination
-                total={data?.data.page_meta_data.total_count}
+                total={promptListData?.data.page_meta_data.total_count}
                 pageSize={10}
                 onChange={handleOnChange}
                 showSizeChanger={false}
+            />
+
+            {/* Tutorial Tour*/}
+            <Tour
+                open={isTour}
+                onClose={() => setIsTour(false)}
+                steps={steps}
+                zIndex={999}
             />
         </ListContainer>
     );

--- a/src/components/main/List.tsx
+++ b/src/components/main/List.tsx
@@ -1,25 +1,25 @@
-import { Button, Empty, Pagination, Result, Tour, TourProps } from "antd";
+import { Button, Empty, Pagination, Result } from "antd";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { useGetPromptList } from "../../hooks/queries/prompt/useGetPromptList";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import ListItem from "./ListItem";
 import Search from "./Search";
-import dummies from "../../pages/tutorial/dummies.json";
-import { GetPromptResponse } from "../../hooks/queries/prompt/useGetPrompt";
-import { useUser } from "../../hooks/useUser";
+// import dummies from "../../pages/tutorial/dummies.json";
+// import { GetPromptResponse } from "../../hooks/queries/prompt/useGetPrompt";
+// import { useUser } from "../../hooks/useUser";
 import SortSelectBox from "../prompt/SortSelectBox";
 
-const tutorial = dummies.data as GetPromptResponse;
+// const tutorial = dummies.data as GetPromptResponse;
 
 interface ListProps {
     type: string;
-    onChangeTab: (tab: string) => void;
+    onChangeTab?: (tab: string) => void;
 }
 export default function List({ type, onChangeTab }: ListProps) {
     const navigate = useNavigate();
 
-    const { userData } = useUser();
+    // const { userData } = useUser();
 
     const [page, setPage] = useState(1);
     const [query, setQuery] = useState<string | undefined>();
@@ -30,20 +30,6 @@ export default function List({ type, onChangeTab }: ListProps) {
         query: query,
         sort_by: sortBy,
     });
-
-    const extra = useMemo(() => {
-        if (type === "starred")
-            return (
-                <Button
-                    type="primary"
-                    style={{ width: "100%" }}
-                    onClick={() => onChangeTab("open")}
-                >
-                    지금 바로 둘러보기
-                </Button>
-            );
-        else <></>;
-    }, [type, onChangeTab]);
 
     // 페이지 변경 시,
     function handleOnChange(page: number, pageSize: number) {
@@ -61,65 +47,88 @@ export default function List({ type, onChangeTab }: ListProps) {
     }
 
     // TODO
-    const showTutorial = useMemo(
-        () => userData?.user?.total_prompt_executions === 0,
-        [userData]
-    );
+    // const showTutorial = useMemo(
+    //     () => userData?.user?.total_prompt_executions === 0,
+    //     [userData]
+    // );
 
-    const [isTour, setIsTour] = useState(showTutorial);
-    const tutorialRef = useRef(null);
-    const steps: TourProps["steps"] = [
-        {
-            title: "프롬프트 사용 튜토리얼",
-            description: "해당 프롬프트를 클릭해 보세요",
-            target: () => tutorialRef.current!!,
-            nextButtonProps: {
-                onClick: function navigateToTutorialPrompt() {
-                    navigate("/prompt/tutorial");
-                },
-            },
-        },
-    ];
+    // const [isTour, setIsTour] = useState(showTutorial);
+    // const tutorialRef = useRef(null);
+    // const steps: TourProps["steps"] = [
+    //     {
+    //         title: "프롬프트 사용 튜토리얼",
+    //         description: "해당 프롬프트를 클릭해 보세요",
+    //         target: () => tutorialRef.current!!,
+    //         nextButtonProps: {
+    //             onClick: function navigateToTutorialPrompt() {
+    //                 navigate("/prompt/tutorial");
+    //             },
+    //         },
+    //     },
+    // ];
 
-    if (showTutorial) {
-        return (
-            <ListContainer>
-                <Search onEnter={handleOnEnter} onClear={handleOnClear} />
+    // if (showTutorial) {
+    //     return (
+    //         <ListContainer>
+    //             <Search onEnter={handleOnEnter} onClear={handleOnClear} />
 
-                <FilterContainer>
-                    <SortSelectBox
-                        onSelect={(value) => {
-                            setSortBy(value);
-                        }}
-                    />
-                </FilterContainer>
+    //             <FilterContainer>
+    //                 <SortSelectBox
+    //                     onSelect={(value) => {
+    //                         setSortBy(value);
+    //                     }}
+    //                 />
+    //             </FilterContainer>
 
-                {/* Tutorial */}
-                {showTutorial && (
-                    <div ref={tutorialRef}>
-                        <ListItem
-                            key={"tutorial"}
-                            prompt={tutorial}
-                            onClick={() => navigate(`/prompt/tutorial`)}
-                        />
-                    </div>
-                )}
+    //             {/* Tutorial */}
+    //             {showTutorial && (
+    //                 <div ref={tutorialRef}>
+    //                     <ListItem
+    //                         key={"tutorial"}
+    //                         prompt={tutorial}
+    //                         onClick={() => navigate(`/prompt/tutorial`)}
+    //                     />
+    //                 </div>
+    //             )}
 
-                {/* Tutorial Tour*/}
-                <Tour
-                    open={isTour}
-                    onClose={() => setIsTour(false)}
-                    steps={steps}
-                    zIndex={999}
+    //             {/* Tutorial Tour*/}
+    //             <Tour
+    //                 open={isTour}
+    //                 onClose={() => setIsTour(false)}
+    //                 steps={steps}
+    //                 zIndex={999}
+    //             />
+    //         </ListContainer>
+    //     );
+    // }`
+
+    const EmptyResult = useMemo(() => {
+        const handleOnChangeTab = () => {
+            if (onChangeTab) onChangeTab("open");
+        };
+
+        if (type === "starred")
+            return (
+                <Result
+                    icon={null}
+                    extra={
+                        <Button
+                            type="primary"
+                            style={{ width: "100%" }}
+                            onClick={handleOnChangeTab}
+                        >
+                            다른 프롬프트 둘러보기
+                        </Button>
+                    }
                 />
-            </ListContainer>
-        );
-    }
+            );
+
+        return <Result icon={<Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />} />;
+    }, [type, onChangeTab]);
 
     return (
         <ListContainer>
             <Search onEnter={handleOnEnter} onClear={handleOnClear} />
-
             <FilterContainer>
                 <SortSelectBox
                     onSelect={(value) => {
@@ -129,10 +138,7 @@ export default function List({ type, onChangeTab }: ListProps) {
             </FilterContainer>
 
             {!promptListData?.data.page_meta_data.total_count && (
-                <Result
-                    icon={<Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />}
-                    extra={extra}
-                />
+                <>{EmptyResult}</>
             )}
 
             {promptListData?.data.prompt_info_list.map((pt) => (

--- a/src/components/main/List.tsx
+++ b/src/components/main/List.tsx
@@ -8,6 +8,7 @@ import Search from "./Search";
 import dummies from "../../pages/tutorial/dummies.json";
 import { GetPromptResponse } from "../../hooks/queries/prompt/useGetPrompt";
 import { useUser } from "../../hooks/useUser";
+import SortSelectBox from "../prompt/SortSelectBox";
 
 const tutorial = dummies.data as GetPromptResponse;
 
@@ -21,11 +22,12 @@ export default function List({ type }: ListProps) {
 
     const [page, setPage] = useState(1);
     const [query, setQuery] = useState<string | undefined>();
+    const [sortBy, setSortBy] = useState<string>();
     const { data: promptListData } = useGetPromptList({
         view_type: type,
         page: page,
         query: query,
-        sort_by: "relevance",
+        sort_by: sortBy,
     });
 
     // 페이지 변경 시,
@@ -74,6 +76,15 @@ export default function List({ type }: ListProps) {
         <ListContainer>
             <Search onEnter={handleOnEnter} onClear={handleOnClear} />
 
+            <FilterContainer>
+                <SortSelectBox
+                    onSelect={(value) => {
+                        console.log("th", value);
+                        setSortBy(value);
+                    }}
+                />
+            </FilterContainer>
+
             {!promptListData?.data.page_meta_data.total_count && (
                 <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
             )}
@@ -120,4 +131,10 @@ const ListContainer = styled.div`
     gap: 10px;
 
     padding-bottom: 20px;
+`;
+
+const FilterContainer = styled.div`
+    width: 100%;
+    ${({ theme }) => theme.mixins.flexBox("column", "flex-end", "flex-end")};
+    gap: 10px;
 `;

--- a/src/components/main/List.tsx
+++ b/src/components/main/List.tsx
@@ -26,7 +26,7 @@ export default function List({ type, onChangeTab }: ListProps) {
     const [page, setPage] = useState(1);
     const [query, setQuery] = useState<string | undefined>();
     const [sortBy, setSortBy] = useState<string>(Object.keys(SortBy)[0]);
-    const [categories, setCategories] = useState<string[]>();
+    const [categories, setCategories] = useState<string>();
     const { data: promptListData } = useGetPromptList({
         view_type: type,
         page: page,

--- a/src/components/prompt/FilterSelectBox.tsx
+++ b/src/components/prompt/FilterSelectBox.tsx
@@ -5,39 +5,37 @@ import { useState } from "react";
 const CategoriesOptions = Object.entries(Categories);
 
 interface FilterSelectBoxProps {
-    onChange: (values: string[]) => void;
+    // onChange: (values: string[]) => void;
+    onChange: (values: string | undefined) => void;
 }
 export default function FilterSelectBox({ onChange }: FilterSelectBoxProps) {
-    const [filters, setFilters] = useState<string[]>([]);
+    // const [filters, setFilters] = useState<string[]>([]);
 
-    const handleSelect = (value: string) => {
-        const updatedFilters = [...filters, value];
-        setFilters(updatedFilters);
-        onChange(updatedFilters);
-    };
+    // const handleSelect = (value: string) => {
+    //     const updatedFilters = [...filters, value];
+    //     setFilters(updatedFilters);
+    //     onChange(updatedFilters);
+    // };
 
-    const handleDeselect = (value: string) => {
-        const updatedFilters = filters.filter((filter) => filter !== value);
-        setFilters(updatedFilters);
-        onChange(updatedFilters);
-    };
+    // const handleDeselect = (value: string) => {
+    //     const updatedFilters = filters.filter((filter) => filter !== value);
+    //     setFilters(updatedFilters);
+    //     onChange(updatedFilters);
+    // };
 
-    const handleOnClear = () => {
-        const updatedFilters: string[] = [];
-        setFilters(updatedFilters);
-        onChange(updatedFilters);
-    };
+    // const handleOnClear = () => {
+    //     const updatedFilters: string[] = [];
+    //     setFilters(updatedFilters);
+    //     onChange(updatedFilters);
+    // };
 
     return (
         <Select
             style={{ minWidth: "100px" }}
             allowClear
-            mode="tags"
             placeholder="필터"
-            value={filters}
-            onSelect={handleSelect}
-            onDeselect={handleDeselect}
-            onClear={handleOnClear}
+            onSelect={(value) => onChange(value)}
+            onClear={() => onChange(undefined)}
         >
             {CategoriesOptions.map(([key, value]) => (
                 <Select.Option key={value.en} value={key}>

--- a/src/components/prompt/FilterSelectBox.tsx
+++ b/src/components/prompt/FilterSelectBox.tsx
@@ -1,0 +1,49 @@
+import { Select } from "antd";
+import { Categories } from "../../core/Prompt";
+import { useState } from "react";
+
+const CategoriesOptions = Object.entries(Categories);
+
+interface FilterSelectBoxProps {
+    onChange: (values: string[]) => void;
+}
+export default function FilterSelectBox({ onChange }: FilterSelectBoxProps) {
+    const [filters, setFilters] = useState<string[]>([]);
+
+    const handleSelect = (value: string) => {
+        const updatedFilters = [...filters, value];
+        setFilters(updatedFilters);
+        onChange(updatedFilters);
+    };
+
+    const handleDeselect = (value: string) => {
+        const updatedFilters = filters.filter((filter) => filter !== value);
+        setFilters(updatedFilters);
+        onChange(updatedFilters);
+    };
+
+    const handleOnClear = () => {
+        const updatedFilters: string[] = [];
+        setFilters(updatedFilters);
+        onChange(updatedFilters);
+    };
+
+    return (
+        <Select
+            style={{ minWidth: "100px" }}
+            allowClear
+            mode="tags"
+            placeholder="필터"
+            value={filters}
+            onSelect={handleSelect}
+            onDeselect={handleDeselect}
+            onClear={handleOnClear}
+        >
+            {CategoriesOptions.map(([key, value]) => (
+                <Select.Option key={value.en} value={key}>
+                    {value.ko}
+                </Select.Option>
+            ))}
+        </Select>
+    );
+}

--- a/src/components/prompt/InfoDrawer.tsx
+++ b/src/components/prompt/InfoDrawer.tsx
@@ -1,5 +1,6 @@
 import { Descriptions, Drawer } from "antd";
 import { GetPromptResponse } from "../../hooks/queries/prompt/useGetPrompt";
+import { Categories } from "../../core/Prompt";
 
 interface InfoDrawerProps {
     info: GetPromptResponse;
@@ -20,7 +21,9 @@ export default function InfoDrawer({ isOpen, onClose, info }: InfoDrawerProps) {
                 </Descriptions.Item>
 
                 <Descriptions.Item label="카테고리">
-                    {info?.categories.join(", ")}
+                    {info?.categories
+                        .map((cat) => Categories[cat].ko)
+                        .join(", ")}
                 </Descriptions.Item>
 
                 <Descriptions.Item label="사용된 횟수">

--- a/src/components/prompt/SortSelectBox.tsx
+++ b/src/components/prompt/SortSelectBox.tsx
@@ -1,0 +1,19 @@
+import { Select } from "antd";
+import { SortBy } from "../../core/Prompt";
+
+const SortByOptions = Object.entries(SortBy);
+
+interface SortByBoxProps {
+    onSelect: (value: string) => void;
+}
+export default function SortSelectBox({ onSelect }: SortByBoxProps) {
+    return (
+        <Select onSelect={onSelect} defaultValue={SortByOptions[0]}>
+            {SortByOptions.map(([key, value]) => (
+                <Select.Option key={value} value={key}>
+                    {value}
+                </Select.Option>
+            ))}
+        </Select>
+    );
+}

--- a/src/components/prompt/SortSelectBox.tsx
+++ b/src/components/prompt/SortSelectBox.tsx
@@ -8,7 +8,11 @@ interface SortByBoxProps {
 }
 export default function SortSelectBox({ onSelect }: SortByBoxProps) {
     return (
-        <Select onSelect={onSelect} defaultValue={SortByOptions[0]}>
+        <Select
+            onSelect={onSelect}
+            defaultValue={SortByOptions[0]}
+            style={{ minWidth: "100px" }}
+        >
             {SortByOptions.map(([key, value]) => (
                 <Select.Option key={value} value={key}>
                     {value}

--- a/src/components/prompt/TopBox.tsx
+++ b/src/components/prompt/TopBox.tsx
@@ -26,7 +26,7 @@ export default function TopBox({
 interface InfoButtonProps {
     onInformationClick: () => void;
 }
-const InfoButton = ({ onInformationClick }: InfoButtonProps) => {
+export const InfoButton = ({ onInformationClick }: InfoButtonProps) => {
     return (
         <Tooltip title="information">
             <Button
@@ -38,7 +38,7 @@ const InfoButton = ({ onInformationClick }: InfoButtonProps) => {
     );
 };
 
-const InfoBoxWrapper = styled.div`
+export const InfoBoxWrapper = styled.div`
     width: 100%;
 
     ${({ theme }) => theme.mixins.flexBox("row", "flex-end", "center")};

--- a/src/core/Prompt.ts
+++ b/src/core/Prompt.ts
@@ -35,3 +35,10 @@ export enum AIPlatformType {
 }
 
 export type TypeOfAIPlatformType = AIPlatformType;
+
+export const SortBy = {
+    created_at: "최신순",
+    star: "즐겨찾기 순",
+    usages: "사용 많은 순",
+    //    "relevance": ""
+};

--- a/src/core/Prompt.ts
+++ b/src/core/Prompt.ts
@@ -37,8 +37,8 @@ export enum AIPlatformType {
 export type TypeOfAIPlatformType = AIPlatformType;
 
 export const SortBy = {
-    created_at: "최신순",
+    created_at: "최신 순",
     star: "즐겨찾기 순",
     usages: "사용 많은 순",
-    //    "relevance": ""
+    // relevance: "",
 };

--- a/src/core/Prompt.ts
+++ b/src/core/Prompt.ts
@@ -10,7 +10,7 @@ export const Categories: Category = {
     business: { ko: "비즈니스", en: "business" },
     development: { ko: "개발", en: "development" },
     marketing: { ko: "마케팅", en: "marketing" },
-    research: { ko: "리서치", en: "research" },
+    research: { ko: "연구", en: "research" },
     writing: { ko: "글쓰기", en: "writing" },
     productivity: { ko: "생산성", en: "productivity" },
     language: { ko: "언어", en: "language" },

--- a/src/core/Prompt.ts
+++ b/src/core/Prompt.ts
@@ -25,11 +25,7 @@ export enum InputType {
     NUMBER = "number",
 }
 
-export type TypeOfInputType =
-    | InputType.TEXT
-    | InputType.LONGTEXT
-    | InputType.NUMBER
-    | InputType.DROPDOWN;
+export type TypeOfInputType = `${InputType}`;
 
 export enum AIPlatformType {
     CHATGPT = "ChatGPT",

--- a/src/core/Tab.ts
+++ b/src/core/Tab.ts
@@ -1,6 +1,6 @@
 // export const TabList = ["즐겨찾기", "전체", "내 프롬프트"] as const;
 export const TabList = {
-    star: "즐겨찾기",
+    starred: "즐겨찾기",
     open: "전체",
     my: "내 프롬프트",
 };

--- a/src/core/Tab.ts
+++ b/src/core/Tab.ts
@@ -1,1 +1,6 @@
-export const TabList = ["전체", "내 프롬프트", "즐겨찾기"] as const;
+// export const TabList = ["즐겨찾기", "전체", "내 프롬프트"] as const;
+export const TabList = {
+    star: "즐겨찾기",
+    open: "전체",
+    my: "내 프롬프트",
+};

--- a/src/hooks/queries/QueryKeys.ts
+++ b/src/hooks/queries/QueryKeys.ts
@@ -10,4 +10,6 @@ const PROMPT_KEYS = {
     detail: (id: string) => [...PROMPT_KEYS.details(), id] as const, // ["prompts", "detail", "id"]
 };
 
-export { PROMPT_KEYS };
+const USER_KEYS = ["user"];
+
+export { PROMPT_KEYS, USER_KEYS };

--- a/src/hooks/queries/auth/useGetUser.ts
+++ b/src/hooks/queries/auth/useGetUser.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import { GET } from "../../../service/client";
+import { USER_KEYS } from "../QueryKeys";
+
+/**
+ * GetUserResponse
+ */
+export interface GetUserResponse {
+    email: string;
+    nickname: string;
+    picture: string;
+    total_prompt_executions: number;
+}
+
+/**
+ *  유저 정보 조회하기
+ */
+const getUser = async () => {
+    const { data } = await GET<GetUserResponse>(`/me`);
+    return data;
+};
+
+export const useGetUser = () => {
+    const QUERY_KEY = USER_KEYS;
+
+    const { data, isLoading, isError, refetch } = useQuery({
+        queryKey: QUERY_KEY,
+        queryFn: () => getUser().then((res) => res),
+    });
+
+    return { data, isLoading, isError, refetch };
+};

--- a/src/hooks/queries/prompt/useGetPrompt.ts
+++ b/src/hooks/queries/prompt/useGetPrompt.ts
@@ -1,19 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
 import { GET } from "../../../service/client";
-import { CreatePromptRequest } from "../../mutations/prompt/usePostPrompt";
+import {
+    CreatePromptRequest,
+    InputFormat,
+} from "../../mutations/prompt/usePostPrompt";
 import { PROMPT_KEYS } from "../QueryKeys";
 
 /**
  * GetPromptResponse
  */
 export interface GetPromptResponse extends CreatePromptRequest {
+    id: string;
     author_nickname: string;
     star: number;
     usages: number;
-    created: string;
     is_starred_by_user: boolean;
     created_at: string;
-    id?: string;
+    user_input_format: InputFormat[];
 }
 
 /**

--- a/src/hooks/queries/prompt/useGetPromptList.ts
+++ b/src/hooks/queries/prompt/useGetPromptList.ts
@@ -9,8 +9,7 @@ import { PROMPT_KEYS } from "../QueryKeys";
 export interface GetPromptListRequest {
     view_type: string;
     query?: string;
-    categories?: string[];
-    // categories?: string;
+    categories?: string;
     sort_by?: string;
     sort_order?: string;
     limit?: number;

--- a/src/hooks/queries/prompt/useGetPromptList.ts
+++ b/src/hooks/queries/prompt/useGetPromptList.ts
@@ -9,7 +9,8 @@ import { PROMPT_KEYS } from "../QueryKeys";
 export interface GetPromptListRequest {
     view_type: string;
     query?: string;
-    category?: string;
+    categories?: string[];
+    // categories?: string;
     sort_by?: string;
     sort_order?: string;
     limit?: number;

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -11,14 +11,13 @@ export default function HomePage() {
     const navigate = useNavigate();
     const [showVOC, setShowVOC] = useState(false);
 
-    const [tab, setTab] = useState("0");
+    const [tab, setTab] = useState(Object.keys(TabList)[0]);
 
     const handleOnChangeTab = (tab: string) => setTab(tab);
-
     const components = [
         <List type="starred" onChangeTab={handleOnChangeTab} />,
-        <List type="open" onChangeTab={handleOnChangeTab} />,
-        <List type="my" onChangeTab={handleOnChangeTab} />,
+        <List type="open" />,
+        <List type="my" />,
     ];
 
     const operation = (
@@ -34,11 +33,11 @@ export default function HomePage() {
                 items={Object.entries(TabList).map(([key, value], idx) => {
                     return {
                         label: `${value}`,
-                        key: `${idx}`,
+                        key: `${key}`,
                         children: components[idx],
                     };
                 })}
-                tabIndex={Number(tab)}
+                activeKey={tab}
                 onChange={(key) => {
                     setTab(key);
                 }}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -11,10 +11,14 @@ export default function HomePage() {
     const navigate = useNavigate();
     const [showVOC, setShowVOC] = useState(false);
 
+    const [tab, setTab] = useState("0");
+
+    const handleOnChangeTab = (tab: string) => setTab(tab);
+
     const components = [
-        <List type="open" />,
-        <List type="my" />,
-        <List type="starred" />,
+        <List type="starred" onChangeTab={handleOnChangeTab} />,
+        <List type="open" onChangeTab={handleOnChangeTab} />,
+        <List type="my" onChangeTab={handleOnChangeTab} />,
     ];
 
     const operation = (
@@ -27,13 +31,17 @@ export default function HomePage() {
         <HomePageContainer>
             <Tabs
                 tabBarExtraContent={operation}
-                items={TabList.map((tab, idx) => {
+                items={Object.entries(TabList).map(([key, value], idx) => {
                     return {
-                        label: `${tab}`,
-                        key: tab,
+                        label: `${value}`,
+                        key: `${idx}`,
                         children: components[idx],
                     };
                 })}
+                tabIndex={Number(tab)}
+                onChange={(key) => {
+                    setTab(key);
+                }}
             />
 
             <FloatButton

--- a/src/pages/tutorial/TutorialPromptPage.tsx
+++ b/src/pages/tutorial/TutorialPromptPage.tsx
@@ -1,0 +1,181 @@
+import styled from "styled-components";
+import { useRef, useState } from "react";
+
+import Header from "../../components/common/header/AHeader";
+import { Wrapper } from "../../layouts/Layout";
+import Property, { PropertyRef } from "../../components/prompt/Property";
+import {
+    getCurrentTabUrl,
+    insertPromptToDOMInput,
+} from "../../service/chrome/utils";
+
+import { Button, Tour, TourProps } from "antd";
+import { InfoBoxWrapper, InfoButton } from "../../components/prompt/TopBox";
+import InfoDrawer from "../../components/prompt/InfoDrawer";
+import { getAIPlatformType, populateTemplate } from "../../utils";
+import { GetPromptResponse } from "../../hooks/queries/prompt/useGetPrompt";
+
+import NotSupportedModal from "../../components/common/modal/NotSupportedModal";
+import dummies from "./dummies.json";
+import StarButton from "../../components/common/button/StarButton";
+import { AIPlatformType } from "../../core/Prompt";
+
+export default function TutorialPromptPage() {
+    const [showNotSupportedModal, setShowNotSupportedModal] = useState(false);
+    const [prompt, setPrompt] = useState("");
+
+    const [open, setOpen] = useState(false);
+    const propertyRefs = useRef<Record<string, PropertyRef>>({});
+
+    const data = dummies.data as GetPromptResponse;
+    const id = data.id;
+
+    /** TOUR **/
+    const ref1 = useRef(null);
+    const ref2 = useRef(null);
+    const ref3 = useRef(null);
+    const [isTour, setIsTour] = useState(true);
+    const steps: TourProps["steps"] = [
+        {
+            title: "(1) 내용 작성하기",
+            description: "프롬프트에 들어갈 내용을 작성해요",
+            target: () => ref1.current!!,
+            nextButtonProps: {
+                onClick: function fillProperties() {
+                    for (const option of data.user_input_format) {
+                        const key = option.name;
+                        const placeholder = option.placeholder.replace(
+                            "ex. ",
+                            ""
+                        );
+                        if (propertyRefs.current[key]) {
+                            propertyRefs.current[key].setValue(placeholder);
+                        }
+                    }
+                },
+            },
+        },
+        {
+            title: "(2) 프롬프트 사용하기",
+            description: "버튼을 누르면 자동으로 입력 후 전송돼요",
+            target: () => ref2.current,
+        },
+        {
+            title: "(3) 즐겨찾기 등록하기",
+            description: "프롬프트가 마음에 든다면 즐겨찾기를 눌러보세요!",
+            target: () => ref3.current,
+        },
+    ];
+
+    /** EXECUTE **/
+    async function handleUsePrompt() {
+        const propertyValues: Record<string, string> = {};
+
+        for (const key in propertyRefs.current) {
+            if (propertyRefs.current[key]) {
+                propertyValues[key] = propertyRefs.current[key].getValue();
+            }
+        }
+
+        const full_prompt = populateTemplate(
+            data.prompt_template,
+            propertyValues
+        );
+        console.log(full_prompt);
+
+        getCurrentTabUrl((url) => {
+            // 플랫폼 확인 (ChatGPT, Gemini, Claude)
+            if (getAIPlatformType(url) === AIPlatformType.NONE) {
+                console.error("지원하지 않는 플랫폼입니다.");
+                setShowNotSupportedModal(true);
+                setPrompt(full_prompt);
+                return;
+            }
+
+            // Inject
+            insertPromptToDOMInput(full_prompt);
+
+            // Finish!
+        });
+    }
+
+    return (
+        <>
+            <Header title="프롬프트 사용하기" canGoBack={true} />
+            <Wrapper>
+                {data && (
+                    <>
+                        <InfoBoxWrapper>
+                            <span ref={ref3}>
+                                <StarButton
+                                    id={id}
+                                    isFavorite={data.is_starred_by_user}
+                                />
+                            </span>
+                            <InfoButton
+                                onInformationClick={() => setOpen(true)}
+                            />
+                        </InfoBoxWrapper>
+
+                        <Title>{data.title}</Title>
+                        {/* <Description>{data.description}</Description> */}
+
+                        <div ref={ref1}>
+                            {data.user_input_format.map((opt) => (
+                                <Property
+                                    key={opt.name}
+                                    option={opt}
+                                    ref={(el) => {
+                                        if (el)
+                                            propertyRefs.current[opt.name] = el;
+                                    }}
+                                />
+                            ))}
+                        </div>
+
+                        <Button
+                            ref={ref2}
+                            type="primary"
+                            style={{ width: "100%", marginBottom: "30px" }}
+                            onClick={handleUsePrompt}
+                        >
+                            사용
+                        </Button>
+
+                        <InfoDrawer
+                            info={data}
+                            isOpen={open}
+                            onClose={() => setOpen(false)}
+                        />
+                    </>
+                )}
+            </Wrapper>
+
+            <NotSupportedModal
+                isOpen={showNotSupportedModal}
+                prompt={prompt}
+                closeModal={() => setShowNotSupportedModal(false)}
+            />
+
+            <Tour
+                open={isTour}
+                onClose={() => setIsTour(false)}
+                steps={steps}
+                zIndex={999}
+            />
+        </>
+    );
+}
+
+const Title = styled.h2`
+    ${({ theme }) => theme.fonts.title};
+    margin: 10px 0;
+`;
+
+const Description = styled.h2`
+    ${({ theme }) => theme.fonts.placeholder};
+    text-align: center;
+    margin: 10px 0 20px;
+
+    color: ${({ theme }) => theme.colors.main_gray};
+`;

--- a/src/pages/tutorial/TutorialPromptPage.tsx
+++ b/src/pages/tutorial/TutorialPromptPage.tsx
@@ -121,7 +121,10 @@ export default function TutorialPromptPage() {
                 return;
             }
 
-            const full_prompt = populateTemplate(prompt, propertyValues);
+            const full_prompt = populateTemplate(
+                data.prompt_template,
+                propertyValues
+            );
             console.log(">> ", full_prompt);
 
             insertPromptToDOMInput(full_prompt);

--- a/src/pages/tutorial/dummies.json
+++ b/src/pages/tutorial/dummies.json
@@ -1,0 +1,32 @@
+{
+    "data": {
+        "id": "66ba864d843fade61e09d7c7",
+        "title": "마케팅을 위한 카피라이팅 만들기",
+        "description": "각기 다른 컨셉으로 3가지의 카피라이팅을 만들어줍니다",
+        "prompt_template": "너는 고객들의 구매욕구를 자극하는 마케팅 전문가야.\n\n\"{{상품 이름}}\"에 대한 마케팅 카피라이팅을 만들어줘. 예상 청중은 {{예상 청중}}이야.\n\n이들의 마음을 사로잡을 수 있는 매력적이고 센스있는 카피라이팅을 각기 다른 컨셉으로 총 3개 만들어줘.\n\n상품의 특징: {{상품의 특징}}",
+        "visibility": "public",
+        "categories": ["marketing"],
+        "author_nickname": "윤권",
+        "star": 0,
+        "usages": 2,
+        "created_at": "2024-08-13T07:01:49.247000",
+        "user_input_format": [
+            {
+                "name": "상품 이름",
+                "type": "text",
+                "placeholder": "ex. 하림 블랙페퍼 닭가슴살"
+            },
+            {
+                "name": "예상 청중",
+                "type": "text",
+                "placeholder": "ex. 다이어트를 하는 20대 여성"
+            },
+            {
+                "name": "상품의 특징",
+                "type": "text",
+                "placeholder": "ex. 안심할 수 있는 HACCP 인증, 닭고기와 양파 등 함유, 샐러드 토핑 등으로 활용 가능"
+            }
+        ],
+        "is_starred_by_user": false
+    }
+}

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -5,6 +5,7 @@ import HomePage from "../pages/home/HomePage";
 import Layout from "../layouts/Layout";
 import PromptPage from "../pages/prompt/PromptPage";
 import NewPromptPage from "../pages/newPrompt/NewPromptPage";
+// import TutorialPromptPage from "../pages/tutorial/TutorialPromptPage";
 
 const router = createMemoryRouter([
     {
@@ -33,6 +34,10 @@ const router = createMemoryRouter([
                 path: "/prompt/:id",
                 element: <PromptPage />,
             },
+            // {
+            //     path: "/prompt/tutorial",
+            //     element: <TutorialPromptPage />,
+            // },
         ],
     },
 ]);

--- a/src/service/auth/auth.model.ts
+++ b/src/service/auth/auth.model.ts
@@ -13,4 +13,5 @@ export interface UserResponse {
     email: string;
     nickname: string;
     picture: string;
+    total_prompt_executions: number;
 }

--- a/src/service/client.ts
+++ b/src/service/client.ts
@@ -11,7 +11,7 @@ const getAccessToken = (): Promise<string> => {
             });
         else
             resolve(
-                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ5dXNpbmtpbS5vckBnbWFpbC5jb20iLCJleHAiOjE3MjQxNzM0ODB9.uYrVBPhQUAarWu82qaugLoSjSAqju3savhFDoMmtB-M"
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ5dXNpbmtpbS5vckBnbWFpbC5jb20iLCJleHAiOjE3MjYxNDAxNTN9.57ctmfKsz_8MSNF6Zeb16IlGxBKbuF7Fbfk9K7ZebMI"
             );
     });
 };

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -66,6 +66,19 @@ body {
     height: 100%;
     background: #efefef;
 }
+
+
+// Ant Design Tour 
+.ant-tour {
+    max-width: fit-content;
+    max-height: fit-content;
+
+    padding: 20px;
+p}
+
+.ant-tour-content {
+    margin: auto;
+}
 `;
 
 export default GlobalStyle;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -77,6 +77,9 @@ body {
 p}
 
 .ant-tour-content {
+    max-width: fit-content;
+    max-height: fit-content;
+
     margin: auto;
 }
 `;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,18 +18,18 @@ export function extractOptions(text: string): string[] {
 }
 
 // 240722 미사용 - 백에서 처리
-// /**
-//  * 입력받은 value들을 $$ 영역에 replace한 텍스트를 리턴하는 함수
-//  * @param template
-//  * @param values
-//  * @returns replace한 텍스트
-//  */
-// export function populateTemplate(
-//     template: string,
-//     values: Record<string, string>
-// ): string {
-//     return template.replace(/\$(.*?)\$/g, (_, key) => values[key]);
-// }
+/**
+ * 입력받은 value들을 {{}} 영역에 replace한 텍스트를 리턴하는 함수
+ * @param template
+ * @param values
+ * @returns replace한 텍스트
+ */
+export function populateTemplate(
+    template: string,
+    values: Record<string, string>
+): string {
+    return template.replace(/\{\{(.*?)\}\}/g, (_, key) => values[key]);
+}
 
 /**
  * 현재 url에 해당하는 AI Platform Type을 리턴하는 함수


### PR DESCRIPTION
## 🪄 Issue Number
- close #32 

## 🏆 Details
- [x] 반짝이 효과 제거
- [x] 카테고리 리서치 -> 연구로 변경
- [x] 검색에 정렬, 필터링 기능 추가
- [x] 기본 진입 탭 '즐겨찾기'로 변경
- [x] 즐겨찾기 없을 시, CTA 노출  


## 📸 Screenshot

| 검색에 정렬, 필터링 기능 추가 | 기본 탭 '즐겨찾기'로 변경 |
| - | - |
| <video src="https://github.com/user-attachments/assets/50633af3-092f-4cef-a3f3-c905259c0624" /> | <video src="https://github.com/user-attachments/assets/7e862b60-9e8f-4971-b8be-408551060f20" /> |



## ✅ Need Review

**1. 리스트 조회 API 카테고리 단일 필터링만 가능**
    : categories 값에 필터 여러개 배열로 보내면 필터링 되지 않아, 단일 필터링으로만 구현함

| 배열로 보낼 시 - 오류 | 단일로 보냄 |
| - | - |
| <img width="883" alt="image" src="https://github.com/user-attachments/assets/0c57f940-447a-4ce6-a969-98778038eb72"> | <img width="895" alt="image" src="https://github.com/user-attachments/assets/721ea7e9-8e1f-4453-b8f2-1b203a8eb635"> |



**2. 즐겨찾기 없을 시, CTA 버튼 문구** 
    : 문구 변경할 거 알려 준다고 했던 것 같은데, 알려주면 반영 예정 